### PR TITLE
Add two overloads of DesignTokens() factory function

### DIFF
--- a/composetheme/src/commonMain/kotlin/com.composables.composetheme/ComposeTheme.kt
+++ b/composetheme/src/commonMain/kotlin/com.composables.composetheme/ComposeTheme.kt
@@ -134,6 +134,13 @@ fun <T> DesignTokens(vararg pairs: Pair<DesignToken<T>, T>): DesignTokens<T> {
     return DesignTokens(entries = pairs.toMap(), propertyName = "")
 }
 
+fun <T> DesignTokens(pairs: List<Pair<DesignToken<T>, T>>): DesignTokens<T> {
+    return DesignTokens(entries = pairs.toMap(), propertyName = "")
+}
+
+fun <T> DesignTokens(pairs: Map<DesignToken<T>, T>): DesignTokens<T> {
+    return DesignTokens(entries = pairs, propertyName = "")
+}
 
 @Composable
 @ReadOnlyComposable


### PR DESCRIPTION
This PR offers two more overloads of `DesignTokens()`. The existing ones take a single `Pair<DesignToken<T>, T>` or a `vararg` of them. The overloads accept a `List<Pair<DesignToken<T>, T>>` or a `Map<DesignToken<T>, T>`, the latter being what we want in the end anyway.

---

For testing theme construction, it is useful to be able to inspect the design tokens that we are defining. For example, we can confirm that both the light and dark themes have the same tokens (i.e., we're not missing one in one theme) and that their colors are distinct (outside of an allowlist).

However, `DesignTokens` hides those details. That's understandable, but it means that we need to test at the level of the `Pair<DesignToken<T>, T>` roster that we build up. It feels like the most straightforward way to do that is:

- Have something `internal` to the design system module that exposes `listOf()` or `arrayOf()` the token/value pairs
- Write tests for that list or array
- Have something else wrap that list or array in the `DesignTokens` as part of `buildComposeTheme()`

We can get away with the existing `DesignTokens()` API for that, using the spread operator to convert between the list/array and the `vararg`. However, as Detekt points out:

> In most cases using a spread operator causes a full copy of the array to be created before calling a method. This may result in a performance penalty.

These overloads simply allow us to avoid the spread operator.

If there is a better solution for the testing approach that I missed, where we can avoid adding these overloads, I'd love to hear about it.

Thanks for considering this contribution, and thanks for creating this library!